### PR TITLE
Remove power shell feed credentials

### DIFF
--- a/DSC/Build/Tasks/Init.ps1
+++ b/DSC/Build/Tasks/Init.ps1
@@ -1,5 +1,9 @@
 Task Init {
 
+    if ($PSVersionTable.PSEdition -ne 'Desktop') {
+        Write-Error "The build script required Windows PowerShell 5.1 to work" 
+    }
+
     if (-not $env:BHProjectName) {
         try {
             Write-Host "Calling 'Set-BuildEnvironment' with path '$ProjectPath'"

--- a/Lab/31 New Release Pipleine CommonTasks.ps1
+++ b/Lab/31 New Release Pipleine CommonTasks.ps1
@@ -217,9 +217,6 @@ Invoke-LabCommand -ActivityName 'Set RepositoryUri and create Build Pipeline' -S
     git checkout dev *>$null
     $c = Get-Content '.\azure-pipelines On-Prem.yml' -Raw
     $c = $c -replace '  RepositoryUri: ggggg', "  RepositoryUri: $($nugetFeed.NugetV2Url)"
-    $c = $c -replace '  Domain: ddddd', "  Domain: $($nugetFeed.NugetCredential.GetNetworkCredential().Domain)"
-    $c = $c -replace '  UserName: uuuuu', "  Username: $($nugetFeed.NugetCredential.GetNetworkCredential().UserName)"
-    $c = $c -replace '  Password: ppppp', "  Password: $($nugetFeed.NugetCredential.GetNetworkCredential().Password)"
     $c | Set-Content '.\azure-pipelines.yml'
     git add .
     git commit -m 'Set RepositoryUri and create Build Pipeline'

--- a/Lab/32 New Release Pipleine DscWorkshop.ps1
+++ b/Lab/32 New Release Pipleine DscWorkshop.ps1
@@ -529,9 +529,6 @@ Invoke-LabCommand -ActivityName 'Set RepositoryUri and create Build Pipeline' -S
     git checkout dev *>$null
     $c = Get-Content '.\azure-pipelines On-Prem.yml' -Raw
     $c = $c -replace '  RepositoryUri: ggggg', "  RepositoryUri: $($nugetFeed.NugetV2Url)"
-    $c = $c -replace '  Domain: ddddd', "  Domain: $($nugetFeed.NugetCredential.GetNetworkCredential().Domain)"
-    $c = $c -replace '  UserName: uuuuu', "  Username: $($nugetFeed.NugetCredential.GetNetworkCredential().UserName)"
-    $c = $c -replace '  Password: ppppp', "  Password: $($nugetFeed.NugetCredential.GetNetworkCredential().Password)"
     $c | Set-Content '.\azure-pipelines.yml'
     git add .
     git commit -m 'Set RepositoryUri and create Build Pipeline'

--- a/azure-pipelines On-Prem.yml
+++ b/azure-pipelines On-Prem.yml
@@ -5,10 +5,7 @@ trigger:
 
 variables:
   RepositoryUri: ggggg #will be replaced during lab deployment
-  Domain: ddddd #will be replaced during lab deployment
-  UserName: uuuuu #will be replaced during lab deployment
-  Password: ppppp #will be replaced during lab deployment
-
+  
 jobs:
 - job: DscBuild
   strategy:
@@ -27,16 +24,11 @@ jobs:
           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
           $uri = '$(RepositoryUri)'
           $name = 'PowerShell'
-          $domain = '$(Domain)'
-          $userName = '$(UserName)'
-          $password = '$(Password)'
-          $cred = New-Object pscredential("$domain\$userName", ($password | ConvertTo-SecureString -AsPlainText -Force))
-          Write-Host "Credentials for repository: '$domain\$userName' '$password'"
           $r = Get-PSRepository -Name $name -ErrorAction SilentlyContinue
           if (-not $r -or $r.SourceLocation -ne $uri -or $r.PublishLocation -ne $uri) {
               Write-Host "The Source or PublishLocation of the repository '$name' is not correct or the repository is not registered"
               Unregister-PSRepository -Name $name -ErrorAction SilentlyContinue
-              Register-PSRepository -Name $name -SourceLocation $uri -PublishLocation $uri -InstallationPolicy Trusted -Credential $cred
+              Register-PSRepository -Name $name -SourceLocation $uri -PublishLocation $uri -InstallationPolicy Trusted
               Get-PSRepository
           }
         errorActionPreference: stop


### PR DESCRIPTION
Turns out that the network service account / computer account of the build workers can access the Azure DevOps artifact feed without explicit credentials.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscworkshop/86)
<!-- Reviewable:end -->
