### PR TITLE
Removed a Space from the Path causing Failure

### DIFF
--- a/Exercises/Task3/Exercise4.md
+++ b/Exercises/Task3/Exercise4.md
@@ -100,7 +100,7 @@ For now, we will only upload the MOF files to Azure Automation, but you can add 
     $automationAccountName = $env:AutomationAccountName
     $storageContainerName = 'DscModules'
 
-    $path = "$($env:SYSTEM_ARTIFACTSDIRECTORY)\$($env:RELEASE_PRIMARYARTIFACTSOURCEALIAS)\Compressed Modules"
+    $path = "$($env:SYSTEM_ARTIFACTSDIRECTORY)\$($env:RELEASE_PRIMARYARTIFACTSOURCEALIAS)\CompressedModules"
 
     if (Get-Command Enable-AzureRMAlias -ErrorAction SilentlyContinue)
         {


### PR DESCRIPTION
Corrected:
$path = "$($env:SYSTEM_ARTIFACTSDIRECTORY)\$($env:RELEASE_PRIMARYARTIFACTSOURCEALIAS)\Compressed Modules"
to
$path = "$($env:SYSTEM_ARTIFACTSDIRECTORY)\$($env:RELEASE_PRIMARYARTIFACTSOURCEALIAS)\CompressedModules"
To stop failure on release pipeline due to inability to find path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscworkshop/115)
<!-- Reviewable:end -->
