### PR TITLE
Removed dependency to GitVersion

### DIFF
--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -30,6 +30,7 @@
     Configuration                = 'latest'
     Metadata                     = 'latest'
     xDscResourceDesigner         = 'latest'
+    'DscResource.Test'           = 'latest'
 
     # Composites
     CommonTasks                  = '0.3.259'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -18,7 +18,7 @@
     Sampler                      = 'latest'
     'Sampler.GitHubTasks'        = 'latest'
     PowerShellForGitHub          = 'latest'
-    'Sampler.DscPipeline'        = '0.1.1-preview0001'
+    'Sampler.DscPipeline'        = '0.1.1-preview0002'
     MarkdownLinkCheck            = 'latest'
     'DscResource.AnalyzerRules'  = 'latest'
     DscBuildHelpers              = 'latest'

--- a/source/DscWorkshop.psd1
+++ b/source/DscWorkshop.psd1
@@ -1,0 +1,26 @@
+@{
+    RootModule        = 'DscWorkshop.psm1'
+    ModuleVersion     = '0.4'
+    GUID              = '63e8bf79-62d3-4249-8fe6-9a766fbe8481'
+    Author            = 'DSC Community'
+    CompanyName       = 'DSC Community'
+    Copyright         = 'Copyright the DSC Community contributors. All rights reserved.'
+    Description       = 'DSC composite resource for https://github.com/dsccommunity/DscWorkshop'
+    PowerShellVersion = '5.1'
+    FunctionsToExport = '*'
+    CmdletsToExport   = '*'
+    VariablesToExport = '*'
+    AliasesToExport   = '*'
+
+    PrivateData       = @{
+
+        PSData = @{
+            Prerelease   = ''
+            Tags         = @('DesiredStateConfiguration', 'DSC', 'DSCResource')
+            LicenseUri   = 'https://github.com/dsccommunity/DscWorkshop/blob/main/LICENSE'
+            ProjectUri   = 'https://github.com/dsccommunity/DscWorkshop'
+            IconUri      = 'https://dsccommunity.org/images/DSC_Logo_300p.png'
+            ReleaseNotes = ''
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

GitVersion was required for the build to succeed in order to get the version number. Sampler looks for GitVersion first, and if it is not available tries to get the version number from the psd1 file which was missing.

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/dscworkshop/125)
<!-- Reviewable:end -->
