### PR TITLE
Fixed deploy state

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,6 @@ trigger:
 
 variables:
   buildFolderName: output
-  buildArtifactName: output
   testResultFolderName: testResults
   defaultBranch: main
   Agent.Source.Git.ShallowFetchDepth: 0
@@ -219,7 +218,7 @@ stages:
             displayName: 'Download Build Artifact'
             inputs:
               buildType: 'current'
-              artifactName: $(buildArtifactName)
+              artifactName: 'output7'
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
           - task: PowerShell@2
             name: publishRelease


### PR DESCRIPTION
This pull request makes a minor update to the Azure Pipelines configuration by changing the artifact name used in the build and release process.

* The `artifactName` input in the "Download Build Artifact" task was updated from the variable `$(buildArtifactName)` to the hardcoded value `'output7'` in `azure-pipelines.yml`.
* The unused `buildArtifactName` variable was removed from the variables section in `azure-pipelines.yml`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/DscWorkshop/196)
<!-- Reviewable:end -->
